### PR TITLE
feat: Implement data branch for storing test results with GitHub Pages

### DIFF
--- a/.github/scripts/deploy-to-gh-pages.sh
+++ b/.github/scripts/deploy-to-gh-pages.sh
@@ -1,0 +1,332 @@
+#!/bin/bash
+set -e
+
+# Script to deploy test results to gh-pages branch while preserving history
+# Usage: ./deploy-to-gh-pages.sh <run-id> <run-type> <report-path>
+
+RUN_ID="${1}"
+RUN_TYPE="${2:-sync-test}"  # sync-test or comprehensive
+REPORT_PATH="${3:-./reports}"
+
+if [ -z "$RUN_ID" ]; then
+    echo "Error: Run ID is required"
+    exit 1
+fi
+
+echo "Deploying test results to gh-pages branch..."
+echo "Run ID: $RUN_ID"
+echo "Run Type: $RUN_TYPE"
+echo "Report Path: $REPORT_PATH"
+
+# Configure git
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+
+# Create a temporary directory for gh-pages work
+TEMP_DIR=$(mktemp -d)
+echo "Working in temporary directory: $TEMP_DIR"
+
+# Clone the repository (just the gh-pages branch)
+cd "$TEMP_DIR"
+git clone --branch gh-pages --single-branch "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages || {
+    echo "gh-pages branch doesn't exist, creating it..."
+    git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" gh-pages
+    cd gh-pages
+    git checkout --orphan gh-pages
+    git rm -rf . || true
+    echo "# GitHub Pages" > README.md
+    git add README.md
+    git commit -m "Initialize gh-pages branch"
+    cd ..
+}
+
+cd gh-pages
+
+# Create directory structure
+mkdir -p "runs/${RUN_TYPE}/${RUN_ID}"
+
+# Copy the report files
+cp -r "${GITHUB_WORKSPACE}/${REPORT_PATH}"/* "runs/${RUN_TYPE}/${RUN_ID}/" || {
+    echo "Warning: No report files found in ${REPORT_PATH}"
+}
+
+# Create metadata file for this run
+cat > "runs/${RUN_TYPE}/${RUN_ID}/metadata.json" << EOF
+{
+  "run_id": "${RUN_ID}",
+  "run_type": "${RUN_TYPE}",
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "workflow_run": "${GITHUB_RUN_ID}",
+  "workflow_name": "${GITHUB_WORKFLOW}",
+  "commit_sha": "${GITHUB_SHA}",
+  "ref": "${GITHUB_REF}",
+  "actor": "${GITHUB_ACTOR}"
+}
+EOF
+
+# Generate index.json with all runs
+echo "Generating index.json..."
+cat > index.json << 'EOF'
+{
+  "runs": [
+EOF
+
+first=true
+for run_type_dir in runs/*; do
+    if [ -d "$run_type_dir" ]; then
+        run_type=$(basename "$run_type_dir")
+        for run_dir in "$run_type_dir"/*; do
+            if [ -d "$run_dir" ] && [ -f "$run_dir/metadata.json" ]; then
+                if [ "$first" = true ]; then
+                    first=false
+                else
+                    echo "," >> index.json
+                fi
+                # Extract metadata and add path info
+                jq -c '. + {"path": "'"$run_dir"'"}' "$run_dir/metadata.json" >> index.json
+            fi
+        done
+    fi
+done
+
+cat >> index.json << 'EOF'
+  ]
+}
+EOF
+
+# Generate main index.html
+cat > index.html << 'EOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kurtosis Sync Test Results</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f6f8fa;
+        }
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+        .header {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            padding: 30px;
+            margin-bottom: 20px;
+        }
+        .header h1 {
+            margin: 0;
+            color: #24292e;
+        }
+        .header p {
+            color: #586069;
+            margin-top: 10px;
+        }
+        .filters {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            padding: 20px;
+            margin-bottom: 20px;
+        }
+        .filters select, .filters input {
+            padding: 8px;
+            margin-right: 10px;
+            border: 1px solid #e1e4e8;
+            border-radius: 4px;
+        }
+        .runs-grid {
+            display: grid;
+            gap: 15px;
+        }
+        .run-card {
+            background: white;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            padding: 20px;
+            transition: transform 0.2s;
+        }
+        .run-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 3px 6px rgba(0,0,0,0.15);
+        }
+        .run-card h3 {
+            margin: 0 0 10px 0;
+            color: #0366d6;
+        }
+        .run-card a {
+            text-decoration: none;
+            color: inherit;
+        }
+        .run-metadata {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 10px;
+            color: #586069;
+            font-size: 14px;
+        }
+        .run-metadata dt {
+            font-weight: 600;
+        }
+        .run-type {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            margin-bottom: 10px;
+        }
+        .run-type.comprehensive {
+            background-color: #f3f4f6;
+            color: #4b5563;
+        }
+        .run-type.sync-test {
+            background-color: #e0f2fe;
+            color: #075985;
+        }
+        .loading {
+            text-align: center;
+            padding: 40px;
+            color: #586069;
+        }
+        .error {
+            background-color: #ffeaea;
+            color: #d73a49;
+            padding: 20px;
+            border-radius: 8px;
+            margin: 20px 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Kurtosis Sync Test Results</h1>
+            <p>Historical test runs for Ethereum client synchronization testing</p>
+        </div>
+        
+        <div class="filters">
+            <select id="typeFilter">
+                <option value="">All Types</option>
+                <option value="comprehensive">Comprehensive</option>
+                <option value="sync-test">Individual Tests</option>
+            </select>
+            <input type="date" id="dateFilter" placeholder="Filter by date">
+            <input type="text" id="searchFilter" placeholder="Search runs...">
+        </div>
+        
+        <div id="loading" class="loading">Loading test runs...</div>
+        <div id="error" class="error" style="display: none;"></div>
+        <div id="runs" class="runs-grid"></div>
+    </div>
+
+    <script>
+        async function loadRuns() {
+            const loadingEl = document.getElementById('loading');
+            const errorEl = document.getElementById('error');
+            const runsEl = document.getElementById('runs');
+            
+            try {
+                const response = await fetch('index.json');
+                const data = await response.json();
+                
+                loadingEl.style.display = 'none';
+                displayRuns(data.runs);
+                setupFilters(data.runs);
+            } catch (error) {
+                loadingEl.style.display = 'none';
+                errorEl.style.display = 'block';
+                errorEl.textContent = 'Error loading test runs: ' + error.message;
+            }
+        }
+        
+        function displayRuns(runs) {
+            const runsEl = document.getElementById('runs');
+            
+            // Sort runs by timestamp (newest first)
+            runs.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+            
+            runsEl.innerHTML = runs.map(run => `
+                <div class="run-card">
+                    <a href="${run.path}/index.html">
+                        <span class="run-type ${run.run_type}">${run.run_type.replace('-', ' ')}</span>
+                        <h3>Run #${run.workflow_run || run.run_id}</h3>
+                        <dl class="run-metadata">
+                            <dt>Date:</dt>
+                            <dd>${new Date(run.timestamp).toLocaleString()}</dd>
+                            <dt>Workflow:</dt>
+                            <dd>${run.workflow_name || 'N/A'}</dd>
+                            <dt>Actor:</dt>
+                            <dd>${run.actor || 'N/A'}</dd>
+                            <dt>Commit:</dt>
+                            <dd>${run.commit_sha ? run.commit_sha.substring(0, 7) : 'N/A'}</dd>
+                        </dl>
+                    </a>
+                </div>
+            `).join('');
+        }
+        
+        function setupFilters(runs) {
+            const typeFilter = document.getElementById('typeFilter');
+            const dateFilter = document.getElementById('dateFilter');
+            const searchFilter = document.getElementById('searchFilter');
+            
+            function applyFilters() {
+                const type = typeFilter.value;
+                const date = dateFilter.value;
+                const search = searchFilter.value.toLowerCase();
+                
+                const filtered = runs.filter(run => {
+                    if (type && run.run_type !== type) return false;
+                    if (date) {
+                        const runDate = new Date(run.timestamp).toISOString().split('T')[0];
+                        if (runDate !== date) return false;
+                    }
+                    if (search) {
+                        const searchableText = [
+                            run.run_id,
+                            run.workflow_name,
+                            run.actor,
+                            run.commit_sha
+                        ].join(' ').toLowerCase();
+                        if (!searchableText.includes(search)) return false;
+                    }
+                    return true;
+                });
+                
+                displayRuns(filtered);
+            }
+            
+            typeFilter.addEventListener('change', applyFilters);
+            dateFilter.addEventListener('change', applyFilters);
+            searchFilter.addEventListener('input', applyFilters);
+        }
+        
+        // Load runs on page load
+        loadRuns();
+    </script>
+</body>
+</html>
+EOF
+
+# Add all changes
+git add -A
+
+# Commit changes
+git commit -m "Deploy test results for run ${RUN_ID}" || {
+    echo "No changes to commit"
+    exit 0
+}
+
+# Push to gh-pages branch
+git push origin gh-pages
+
+echo "Successfully deployed to gh-pages branch"
+echo "Results available at: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/runs/${RUN_TYPE}/${RUN_ID}/"

--- a/.github/scripts/save-test-results.sh
+++ b/.github/scripts/save-test-results.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -e
+
+# Script to save test results to the data branch
+# Usage: ./save-test-results.sh
+
+echo "Saving test results to data branch..."
+
+# Check if required environment variables are set
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Error: GITHUB_TOKEN environment variable is required"
+    exit 1
+fi
+
+# Get test metadata
+if [ ! -f "sync-test-results/metadata.json" ]; then
+    echo "Error: sync-test-results/metadata.json not found"
+    exit 1
+fi
+
+# Extract metadata
+METADATA=$(cat sync-test-results/metadata.json)
+NETWORK=$(echo "$METADATA" | jq -r '.network')
+EL_CLIENT=$(echo "$METADATA" | jq -r '.el_client')
+CL_CLIENT=$(echo "$METADATA" | jq -r '.cl_client')
+TIMESTAMP=$(echo "$METADATA" | jq -r '.start_time')
+
+# Generate date-based path
+DATE=$(date -u +%Y-%m-%d)
+TIME=$(date -u +%H-%M-%S)
+
+# Create filename based on test parameters
+FILENAME="${TIME}_${EL_CLIENT}_${CL_CLIENT}.json"
+FILEPATH="results/${DATE}/${NETWORK}/${FILENAME}"
+
+echo "Will save to: $FILEPATH"
+
+# Configure git
+git config --local user.email "action@github.com"
+git config --local user.name "GitHub Action"
+
+# Create a temporary directory for data branch work
+TEMP_DIR=$(mktemp -d)
+echo "Working in temporary directory: $TEMP_DIR"
+
+# Clone only the data branch (or create it if it doesn't exist)
+cd "$TEMP_DIR"
+if git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" data | grep -q data; then
+    echo "Data branch exists, cloning..."
+    git clone --branch data --single-branch --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" data-branch
+else
+    echo "Data branch doesn't exist, creating..."
+    git clone --depth 1 "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" data-branch
+    cd data-branch
+    git checkout --orphan data
+    git rm -rf . 2>/dev/null || true
+    echo "# Test Results Data Branch" > README.md
+    echo "This branch stores test results in JSON format." >> README.md
+    echo "Data is organized by date and network." >> README.md
+    git add README.md
+    git commit -m "Initialize data branch"
+    cd ..
+fi
+
+cd data-branch
+
+# Create directory structure
+mkdir -p "$(dirname "$FILEPATH")"
+
+# Enhanced metadata with additional test information
+ENHANCED_METADATA=$(echo "$METADATA" | jq --arg workflow "$GITHUB_WORKFLOW" \
+    --arg run_id "$GITHUB_RUN_ID" \
+    --arg run_number "$GITHUB_RUN_NUMBER" \
+    --arg sha "$GITHUB_SHA" \
+    --arg ref "$GITHUB_REF" \
+    --arg actor "$GITHUB_ACTOR" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '. + {
+        github: {
+            workflow: $workflow,
+            run_id: $run_id,
+            run_number: $run_number,
+            sha: $sha,
+            ref: $ref,
+            actor: $actor
+        },
+        saved_at: $timestamp
+    }')
+
+# Save enhanced metadata
+echo "$ENHANCED_METADATA" > "$FILEPATH"
+
+# Update daily index for this network
+INDEX_FILE="results/${DATE}/${NETWORK}/index.json"
+if [ -f "$INDEX_FILE" ]; then
+    # Append to existing index
+    EXISTING=$(cat "$INDEX_FILE")
+    echo "$EXISTING" | jq --arg file "$FILENAME" --argjson metadata "$ENHANCED_METADATA" \
+        '.tests += [{filename: $file, metadata: $metadata}]' > "${INDEX_FILE}.tmp"
+    mv "${INDEX_FILE}.tmp" "$INDEX_FILE"
+else
+    # Create new index
+    echo "$ENHANCED_METADATA" | jq --arg file "$FILENAME" \
+        '{date: "'$DATE'", network: "'$NETWORK'", tests: [{filename: $file, metadata: .}]}' > "$INDEX_FILE"
+fi
+
+# Update root catalog
+CATALOG_FILE="catalog.json"
+if [ ! -f "$CATALOG_FILE" ]; then
+    echo '{"last_updated": "", "dates": []}' > "$CATALOG_FILE"
+fi
+
+# Add this date/network to catalog if not already present
+jq --arg date "$DATE" --arg network "$NETWORK" --arg updated "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '
+    .last_updated = $updated |
+    if (.dates | map(select(.date == $date and .network == $network)) | length) == 0 then
+        .dates += [{date: $date, network: $network}]
+    else . end |
+    .dates |= sort_by(.date) | reverse
+' "$CATALOG_FILE" > "${CATALOG_FILE}.tmp"
+mv "${CATALOG_FILE}.tmp" "$CATALOG_FILE"
+
+# Commit and push
+git add -A
+git commit -m "Add test results for ${NETWORK}/${EL_CLIENT}-${CL_CLIENT} at ${DATE} ${TIME}" || {
+    echo "No changes to commit"
+    exit 0
+}
+
+# Push to data branch
+git push origin data
+
+echo "Successfully saved test results to data branch"
+echo "Data available at: https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/data/${FILEPATH}"
+
+# Cleanup
+cd "$GITHUB_WORKSPACE"
+rm -rf "$TEMP_DIR"

--- a/.github/workflows/comprehensive-sync-test.yml
+++ b/.github/workflows/comprehensive-sync-test.yml
@@ -40,9 +40,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   prepare-matrix:
@@ -121,7 +120,8 @@ jobs:
           el_client: ${{ matrix.el_client }}
           cl_client: ${{ matrix.cl_client }}
           wait_time: ${{ github.event.inputs.wait_time || '1800' }}
-          generate_html_report: 'true'
+          generate_html_report: 'false'
+          save_to_data_branch: 'true'
           config_file: 'devnet-templates/devnet-template.yaml'
       
       - name: Upload individual test results
@@ -138,281 +138,87 @@ jobs:
     needs: [prepare-matrix, sync-test]
     if: always()
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      
       - name: Download all test artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./all-results
       
-      - name: Generate comprehensive report
+      - name: Generate test summary
         run: |
-          mkdir -p final-report
-          
-          cat > final-report/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-              <title>Comprehensive Sync Test Results</title>
-              <style>
-                  body {
-                      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                      margin: 0;
-                      padding: 20px;
-                      background-color: #f6f8fa;
-                  }
-                  .container {
-                      max-width: 1400px;
-                      margin: 0 auto;
-                      background: white;
-                      border-radius: 8px;
-                      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-                      padding: 30px;
-                  }
-                  .header {
-                      border-bottom: 1px solid #e1e4e8;
-                      padding-bottom: 20px;
-                      margin-bottom: 30px;
-                  }
-                  .header h1 {
-                      margin: 0;
-                      color: #24292e;
-                  }
-                  .header .subtitle {
-                      color: #586069;
-                      margin-top: 5px;
-                  }
-                  .summary-grid {
-                      display: grid;
-                      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-                      gap: 15px;
-                      margin-bottom: 30px;
-                  }
-                  .summary-card {
-                      border: 1px solid #e1e4e8;
-                      border-radius: 6px;
-                      padding: 20px;
-                      text-align: center;
-                  }
-                  .summary-card h3 {
-                      margin: 0 0 10px 0;
-                      color: #24292e;
-                      font-size: 2em;
-                  }
-                  .summary-card p {
-                      margin: 0;
-                      color: #586069;
-                      font-weight: 600;
-                  }
-                  .results-table {
-                      width: 100%;
-                      border-collapse: collapse;
-                      margin-top: 20px;
-                  }
-                  .results-table th,
-                  .results-table td {
-                      padding: 12px;
-                      text-align: left;
-                      border-bottom: 1px solid #e1e4e8;
-                  }
-                  .results-table th {
-                      background-color: #f6f8fa;
-                      font-weight: 600;
-                      color: #24292e;
-                  }
-                  .status-badge {
-                      display: inline-block;
-                      padding: 4px 8px;
-                      border-radius: 4px;
-                      font-size: 12px;
-                      font-weight: 600;
-                      text-transform: uppercase;
-                  }
-                  .status-badge.success {
-                      background-color: #d4f4dd;
-                      color: #28a745;
-                  }
-                  .status-badge.failure {
-                      background-color: #ffeaea;
-                      color: #d73a49;
-                  }
-                  .status-badge.unknown {
-                      background-color: #fff3cd;
-                      color: #856404;
-                  }
-                  .timestamp {
-                      color: #586069;
-                      font-size: 0.9em;
-                  }
-              </style>
-          </head>
-          <body>
-              <div class="container">
-                  <div class="header">
-                      <h1>Comprehensive Sync Test Results</h1>
-                      <div class="subtitle">Ethereum Client Synchronization Test Report</div>
-                      <div class="timestamp">Generated: <span id="timestamp"></span></div>
-                  </div>
-          EOF
+          echo "## Comprehensive Sync Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
           
           # Process results and generate statistics
           total_tests=0
           successful_tests=0
           failed_tests=0
           
-          echo '<div class="summary-grid">' >> final-report/index.html
-          
-          # Initialize results array for the table
-          echo '<script>var testResults = [];' >> final-report/index.html
-          
           # Process each test result
           for test_dir in ./all-results/test-*; do
             if [ -d "$test_dir" ]; then
               total_tests=$((total_tests + 1))
               
-              # Extract test info from directory name
-              test_name=$(basename "$test_dir")
-              network=$(echo "$test_name" | cut -d'-' -f2)
-              el_client=$(echo "$test_name" | cut -d'-' -f3)
-              cl_client=$(echo "$test_name" | cut -d'-' -f4)
-              
               # Try to read metadata if available
               if [ -f "$test_dir/sync-test-results/metadata.json" ]; then
                 metadata=$(cat "$test_dir/sync-test-results/metadata.json")
                 result=$(echo "$metadata" | jq -r '.result' 2>/dev/null || echo "unknown")
-                duration=$(echo "$metadata" | jq -r '.duration' 2>/dev/null || echo "N/A")
-                start_time=$(echo "$metadata" | jq -r '.start_time' 2>/dev/null || echo "N/A")
-              else
-                result="unknown"
-                duration="N/A"
-                start_time="N/A"
+                
+                # Count results
+                if [ "$result" = "success" ]; then
+                  successful_tests=$((successful_tests + 1))
+                elif [ "$result" = "failure" ]; then
+                  failed_tests=$((failed_tests + 1))
+                fi
               fi
-              
-              # Count results
-              if [ "$result" = "success" ]; then
-                successful_tests=$((successful_tests + 1))
-              elif [ "$result" = "failure" ]; then
-                failed_tests=$((failed_tests + 1))
-              fi
-              
-              # Add to JavaScript array for table
-              echo "testResults.push({" >> final-report/index.html
-              echo "  network: '$network'," >> final-report/index.html
-              echo "  elClient: '$el_client'," >> final-report/index.html
-              echo "  clClient: '$cl_client'," >> final-report/index.html
-              echo "  result: '$result'," >> final-report/index.html
-              echo "  duration: '$duration'," >> final-report/index.html
-              echo "  startTime: '$start_time'" >> final-report/index.html
-              echo "});" >> final-report/index.html
             fi
           done
           
-          echo '</script>' >> final-report/index.html
-          
-          # Add summary cards
+          # Calculate success rate
           success_rate=0
           if [ $total_tests -gt 0 ]; then
             success_rate=$((successful_tests * 100 / total_tests))
           fi
           
-          cat >> final-report/index.html << EOF
-              <div class="summary-card">
-                  <h3>$total_tests</h3>
-                  <p>Total Tests</p>
-              </div>
-              <div class="summary-card">
-                  <h3>$successful_tests</h3>
-                  <p>Successful</p>
-              </div>
-              <div class="summary-card">
-                  <h3>$failed_tests</h3>
-                  <p>Failed</p>
-              </div>
-              <div class="summary-card">
-                  <h3>$success_rate%</h3>
-                  <p>Success Rate</p>
-              </div>
-          </div>
-          
-          <table class="results-table">
-              <thead>
-                  <tr>
-                      <th>Network</th>
-                      <th>EL Client</th>
-                      <th>CL Client</th>
-                      <th>Status</th>
-                      <th>Duration</th>
-                      <th>Start Time</th>
-                  </tr>
-              </thead>
-              <tbody id="resultsTableBody">
-              </tbody>
-          </table>
-          
-          <script>
-              // Set timestamp
-              document.getElementById('timestamp').textContent = new Date().toISOString();
-              
-              // Populate results table
-              const tbody = document.getElementById('resultsTableBody');
-              testResults.forEach(test => {
-                  const row = tbody.insertRow();
-                  row.insertCell(0).textContent = test.network;
-                  row.insertCell(1).textContent = test.elClient;
-                  row.insertCell(2).textContent = test.clClient;
-                  
-                  const statusCell = row.insertCell(3);
-                  const statusBadge = document.createElement('span');
-                  statusBadge.className = 'status-badge ' + test.result;
-                  statusBadge.textContent = test.result;
-                  statusCell.appendChild(statusBadge);
-                  
-                  row.insertCell(4).textContent = test.duration === 'N/A' ? 'N/A' : test.duration + 's';
-                  
-                  const startTimeCell = row.insertCell(5);
-                  if (test.startTime !== 'N/A' && !isNaN(test.startTime)) {
-                      startTimeCell.textContent = new Date(parseInt(test.startTime) * 1000).toLocaleString();
-                  } else {
-                      startTimeCell.textContent = 'N/A';
-                  }
-              });
-          </script>
-          
-          </div>
-          </body>
-          </html>
-          EOF
-          
-          echo "Generated comprehensive report with $total_tests total tests"
-      
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      
-      - name: Upload to Pages
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: final-report/
-      
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-      
-      - name: Create summary
-        run: |
-          echo "## Comprehensive Sync Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Report URL:** ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          total_tests=$(find ./all-results -name "test-*" -type d | wc -l)
           echo "**Total Tests:** $total_tests" >> $GITHUB_STEP_SUMMARY
+          echo "**Successful:** $successful_tests" >> $GITHUB_STEP_SUMMARY
+          echo "**Failed:** $failed_tests" >> $GITHUB_STEP_SUMMARY
+          echo "**Success Rate:** $success_rate%" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Detailed results are available in the GitHub Pages report above." >> $GITHUB_STEP_SUMMARY
+          
+          echo "### Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "| Network | EL Client | CL Client | Status | Duration |" >> $GITHUB_STEP_SUMMARY
+          echo "|---------|-----------|-----------|---------|----------|" >> $GITHUB_STEP_SUMMARY
+          
+          # Generate table rows
+          for test_dir in ./all-results/test-*; do
+            if [ -d "$test_dir" ]; then
+              test_name=$(basename "$test_dir")
+              network=$(echo "$test_name" | cut -d'-' -f2)
+              el_client=$(echo "$test_name" | cut -d'-' -f3)
+              cl_client=$(echo "$test_name" | cut -d'-' -f4)
+              
+              if [ -f "$test_dir/sync-test-results/metadata.json" ]; then
+                metadata=$(cat "$test_dir/sync-test-results/metadata.json")
+                result=$(echo "$metadata" | jq -r '.result' 2>/dev/null || echo "unknown")
+                duration=$(echo "$metadata" | jq -r '.duration' 2>/dev/null || echo "N/A")
+                
+                # Format result with emoji
+                if [ "$result" = "success" ]; then
+                  result_display="✅ Success"
+                elif [ "$result" = "failure" ]; then
+                  result_display="❌ Failure"
+                else
+                  result_display="❓ Unknown"
+                fi
+                
+                echo "| $network | $el_client | $cl_client | $result_display | ${duration}s |" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "| $network | $el_client | $cl_client | ❓ Unknown | N/A |" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View historical results at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/comprehensive-sync-test.yml
+++ b/.github/workflows/comprehensive-sync-test.yml
@@ -121,7 +121,7 @@ jobs:
           cl_client: ${{ matrix.cl_client }}
           wait_time: ${{ github.event.inputs.wait_time || '1800' }}
           generate_html_report: 'false'
-          save_to_data_branch: 'true'
+          save_to_data_branch: 'true'  # Always save results
           config_file: 'devnet-templates/devnet-template.yaml'
       
       - name: Upload individual test results

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'github-pages/**'
+      - '.github/workflows/deploy-github-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build site
+        run: |
+          # Copy github-pages content to _site
+          cp -r github-pages _site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/prune-data-branch.yml
+++ b/.github/workflows/prune-data-branch.yml
@@ -1,0 +1,111 @@
+name: Prune Data Branch
+
+on:
+  schedule:
+    # Run monthly on the 1st at 2:00 AM UTC
+    - cron: '0 2 1 * *'
+  workflow_dispatch:
+    inputs:
+      days_to_keep:
+        description: 'Number of days of data to keep'
+        required: false
+        type: number
+        default: 90
+
+permissions:
+  contents: write
+
+jobs:
+  prune-data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout data branch
+        uses: actions/checkout@v4
+        with:
+          ref: data
+          token: ${{ github.token }}
+      
+      - name: Prune old test results
+        run: |
+          # Get the number of days to keep from input or use default
+          DAYS_TO_KEEP=${{ github.event.inputs.days_to_keep || '90' }}
+          echo "Keeping data from the last $DAYS_TO_KEEP days"
+          
+          # Calculate cutoff date
+          CUTOFF_DATE=$(date -d "$DAYS_TO_KEEP days ago" +%Y-%m-%d)
+          echo "Removing data older than $CUTOFF_DATE"
+          
+          # Configure git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          # Find and remove old data directories
+          removed_count=0
+          if [ -d "results" ]; then
+            for date_dir in results/*/; do
+              if [ -d "$date_dir" ]; then
+                dir_date=$(basename "$date_dir")
+                
+                # Check if directory name is a valid date
+                if [[ "$dir_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                  # Compare dates
+                  if [[ "$dir_date" < "$CUTOFF_DATE" ]]; then
+                    echo "Removing old data: $date_dir"
+                    git rm -rf "$date_dir"
+                    removed_count=$((removed_count + 1))
+                  fi
+                fi
+              fi
+            done
+          fi
+          
+          # Update catalog.json to remove old entries
+          if [ -f "catalog.json" ]; then
+            echo "Updating catalog.json..."
+            
+            # Use jq to filter out old dates
+            jq --arg cutoff "$CUTOFF_DATE" '
+              .dates = (.dates // []) | map(select(.date >= $cutoff))
+            ' catalog.json > catalog.json.tmp
+            
+            mv catalog.json.tmp catalog.json
+            git add catalog.json
+          fi
+          
+          # Commit changes if any files were removed
+          if [ $removed_count -gt 0 ]; then
+            git commit -m "Prune data older than $CUTOFF_DATE ($removed_count date directories removed)"
+            git push origin data
+            echo "Pruned $removed_count old date directories"
+          else
+            echo "No old data to prune"
+          fi
+      
+      - name: Generate size report
+        run: |
+          echo "## Data Branch Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Get repository size
+          echo "### Repository Statistics" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|--------|" >> $GITHUB_STEP_SUMMARY
+          
+          # Count files and calculate size
+          file_count=$(find . -type f -name "*.json" | wc -l)
+          total_size=$(du -sh . | cut -f1)
+          
+          echo "| Total JSON files | $file_count |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total size | $total_size |" >> $GITHUB_STEP_SUMMARY
+          
+          # Get date range of data
+          if [ -d "results" ]; then
+            oldest_date=$(ls results/ | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' | sort | head -n1)
+            newest_date=$(ls results/ | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}$' | sort | tail -n1)
+            
+            echo "| Oldest data | $oldest_date |" >> $GITHUB_STEP_SUMMARY
+            echo "| Newest data | $newest_date |" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Data retention period: ${{ github.event.inputs.days_to_keep || '90' }} days" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -60,9 +60,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
+  pull-requests: write
 
 jobs:
   sync-test:
@@ -115,15 +114,10 @@ jobs:
           cl_client: ${{ steps.matrix.outputs.cl_client }}
           wait_time: ${{ steps.matrix.outputs.wait_time }}
           enclave_name: ${{ steps.matrix.outputs.enclave_name }}
-          generate_html_report: 'true'
+          generate_html_report: 'false'
+          save_to_data_branch: 'true'
           config_file: ${{ steps.matrix.outputs.network == 'fusaka-devnet-1' && 'devnet-templates/devnet-template.yaml' || '' }}
       
-      - name: Upload to Pages (for matrix builds)
-        if: github.event_name == 'schedule'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: sync-test-${{ steps.matrix.outputs.network }}-${{ steps.matrix.outputs.el_client }}-${{ steps.matrix.outputs.cl_client }}
-          path: reports/
       
       - name: Display test summary
         run: |
@@ -135,59 +129,5 @@ jobs:
           echo "**Result:** ${{ steps.sync-test.outputs.test_result }}" >> $GITHUB_STEP_SUMMARY
           echo "**Summary:** ${{ steps.sync-test.outputs.test_summary }}" >> $GITHUB_STEP_SUMMARY
           echo "**Enclave:** ${{ steps.sync-test.outputs.enclave_name }}" >> $GITHUB_STEP_SUMMARY
-
-  # Job for manual dispatch - single test with pages deployment
-  deploy-pages:
-    if: github.event_name == 'workflow_dispatch'
-    needs: sync-test
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    
-    steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: sync-test-results-*
-          path: ./all-reports
-          merge-multiple: true
-      
-      - name: Prepare Pages content
-        run: |
-          mkdir -p pages
-          
-          # Copy reports if they exist
-          if [ -d "./all-reports/reports" ]; then
-            cp -r ./all-reports/reports/* pages/
-          fi
-          
-          # Create index if it doesn't exist
-          if [ ! -f "pages/index.html" ]; then
-            cat > pages/index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-              <title>Sync Test Results</title>
-              <meta charset="UTF-8">
-              <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          </head>
-          <body>
-              <h1>Sync Test Results</h1>
-              <p>No test results available.</p>
-          </body>
-          </html>
-          EOF
-          fi
-      
-      - name: Upload to Pages
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: pages/
-      
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View historical results at: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-test.yml
+++ b/.github/workflows/sync-test.yml
@@ -115,7 +115,7 @@ jobs:
           wait_time: ${{ steps.matrix.outputs.wait_time }}
           enclave_name: ${{ steps.matrix.outputs.enclave_name }}
           generate_html_report: 'false'
-          save_to_data_branch: 'true'
+          save_to_data_branch: 'true'  # Always save results
           config_file: ${{ steps.matrix.outputs.network == 'fusaka-devnet-1' && 'devnet-templates/devnet-template.yaml' || '' }}
       
       

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
   save_to_data_branch:
     description: 'Whether to save results to data branch (requires GITHUB_TOKEN)'
     required: false
-    default: 'false'
+    default: 'true'
   
   kurtosis_version:
     description: 'Version of Kurtosis CLI to use'

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,11 @@ inputs:
     required: false
     default: 'true'
   
+  save_to_data_branch:
+    description: 'Whether to save results to data branch (requires GITHUB_TOKEN)'
+    required: false
+    default: 'false'
+  
   kurtosis_version:
     description: 'Version of Kurtosis CLI to use'
     required: false
@@ -475,6 +480,15 @@ runs:
           sync-test-results/
           reports/
         retention-days: 30
+
+    - name: Save results to data branch
+      if: inputs.save_to_data_branch == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        # Run the save script
+        bash ${{ github.action_path }}/.github/scripts/save-test-results.sh
 
 branding:
   icon: 'sync'

--- a/github-pages/app.js
+++ b/github-pages/app.js
@@ -1,0 +1,311 @@
+// Configuration
+const GITHUB_REPO = 'ethpandaops/kurtosis-sync-test';
+const DATA_BRANCH = 'data';
+const DEFAULT_DAYS = 3;
+
+// Global state
+let allTestResults = [];
+let filteredResults = [];
+let availableNetworks = new Set();
+let trendsChart = null;
+
+// Initialize the app
+async function init() {
+    setupEventListeners();
+    await loadTestResults();
+}
+
+// Setup event listeners
+function setupEventListeners() {
+    document.getElementById('dateRange').addEventListener('change', handleDateRangeChange);
+    document.getElementById('applyFilters').addEventListener('click', applyFilters);
+    
+    // Set default dates
+    const endDate = new Date();
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - DEFAULT_DAYS);
+    
+    document.getElementById('endDate').value = endDate.toISOString().split('T')[0];
+    document.getElementById('startDate').value = startDate.toISOString().split('T')[0];
+}
+
+// Handle date range dropdown change
+function handleDateRangeChange(e) {
+    const customDateRange = document.getElementById('customDateRange');
+    if (e.target.value === 'custom') {
+        customDateRange.style.display = 'flex';
+    } else {
+        customDateRange.style.display = 'none';
+        
+        // Set dates based on selection
+        const days = parseInt(e.target.value);
+        const endDate = new Date();
+        const startDate = new Date();
+        startDate.setDate(startDate.getDate() - days);
+        
+        document.getElementById('endDate').value = endDate.toISOString().split('T')[0];
+        document.getElementById('startDate').value = startDate.toISOString().split('T')[0];
+    }
+}
+
+// Load test results from data branch
+async function loadTestResults() {
+    const loading = document.getElementById('loading');
+    const error = document.getElementById('error');
+    
+    try {
+        // First, fetch the catalog to know what dates/networks are available
+        const catalogUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${DATA_BRANCH}/catalog.json`;
+        const catalogResponse = await fetch(catalogUrl);
+        
+        if (!catalogResponse.ok) {
+            throw new Error('No test data available yet. Run some tests first!');
+        }
+        
+        const catalog = await catalogResponse.json();
+        
+        // Get date range
+        const dateRange = document.getElementById('dateRange').value;
+        const days = dateRange === 'custom' ? 
+            Math.ceil((new Date(document.getElementById('endDate').value) - new Date(document.getElementById('startDate').value)) / (1000 * 60 * 60 * 24)) :
+            parseInt(dateRange);
+        
+        const endDate = dateRange === 'custom' ? 
+            new Date(document.getElementById('endDate').value) :
+            new Date();
+        const startDate = dateRange === 'custom' ?
+            new Date(document.getElementById('startDate').value) :
+            new Date(endDate.getTime() - days * 24 * 60 * 60 * 1000);
+        
+        // Filter catalog entries by date range
+        const relevantEntries = catalog.dates.filter(entry => {
+            const entryDate = new Date(entry.date);
+            return entryDate >= startDate && entryDate <= endDate;
+        });
+        
+        // Load all relevant test results
+        allTestResults = [];
+        availableNetworks.clear();
+        
+        for (const entry of relevantEntries) {
+            availableNetworks.add(entry.network);
+            
+            try {
+                // Fetch the index for this date/network
+                const indexUrl = `https://raw.githubusercontent.com/${GITHUB_REPO}/${DATA_BRANCH}/results/${entry.date}/${entry.network}/index.json`;
+                const indexResponse = await fetch(indexUrl);
+                
+                if (indexResponse.ok) {
+                    const index = await indexResponse.json();
+                    
+                    // Add all tests from this index
+                    for (const test of index.tests) {
+                        allTestResults.push({
+                            ...test.metadata,
+                            date: entry.date,
+                            network: entry.network
+                        });
+                    }
+                }
+            } catch (err) {
+                console.error(`Error loading ${entry.date}/${entry.network}:`, err);
+            }
+        }
+        
+        // Update network filter
+        updateNetworkFilter();
+        
+        // Apply initial filters
+        applyFilters();
+        
+        loading.style.display = 'none';
+    } catch (err) {
+        loading.style.display = 'none';
+        error.style.display = 'block';
+        error.textContent = `Error loading test results: ${err.message}`;
+    }
+}
+
+// Update network filter dropdown
+function updateNetworkFilter() {
+    const networkFilter = document.getElementById('networkFilter');
+    networkFilter.innerHTML = '<option value="">All Networks</option>';
+    
+    Array.from(availableNetworks).sort().forEach(network => {
+        const option = document.createElement('option');
+        option.value = network;
+        option.textContent = network;
+        networkFilter.appendChild(option);
+    });
+}
+
+// Apply filters to test results
+function applyFilters() {
+    const network = document.getElementById('networkFilter').value;
+    const elClient = document.getElementById('elClientFilter').value;
+    const clClient = document.getElementById('clClientFilter').value;
+    const status = document.getElementById('statusFilter').value;
+    
+    filteredResults = allTestResults.filter(test => {
+        if (network && test.network !== network) return false;
+        if (elClient && test.el_client !== elClient) return false;
+        if (clClient && test.cl_client !== clClient) return false;
+        if (status && test.result !== status) return false;
+        return true;
+    });
+    
+    // Sort by date/time descending
+    filteredResults.sort((a, b) => b.start_time - a.start_time);
+    
+    updateSummaryCards();
+    displayResults();
+    updateTrendsChart();
+}
+
+// Update summary cards
+function updateSummaryCards() {
+    const total = filteredResults.length;
+    const successful = filteredResults.filter(t => t.result === 'success').length;
+    const failed = filteredResults.filter(t => t.result === 'failure').length;
+    const successRate = total > 0 ? Math.round((successful / total) * 100) : 0;
+    
+    document.getElementById('totalTests').textContent = total;
+    document.getElementById('successfulTests').textContent = successful;
+    document.getElementById('failedTests').textContent = failed;
+    document.getElementById('successRate').textContent = `${successRate}%`;
+}
+
+// Display results grid
+function displayResults() {
+    const resultsGrid = document.getElementById('resultsGrid');
+    resultsGrid.innerHTML = '';
+    
+    if (filteredResults.length === 0) {
+        resultsGrid.innerHTML = '<p style="text-align: center; color: #586069;">No test results found for the selected filters.</p>';
+        return;
+    }
+    
+    filteredResults.forEach(test => {
+        const card = createResultCard(test);
+        resultsGrid.appendChild(card);
+    });
+}
+
+// Create a result card element
+function createResultCard(test) {
+    const card = document.createElement('div');
+    card.className = 'result-card';
+    
+    const startTime = new Date(test.start_time * 1000);
+    const duration = test.duration ? `${test.duration}s` : 'N/A';
+    
+    card.innerHTML = `
+        <div class="client-info">
+            <div class="client-pair">${test.el_client} + ${test.cl_client}</div>
+        </div>
+        <div class="test-metadata">
+            <div class="metadata-item">
+                <span class="metadata-label">Network</span>
+                <span class="metadata-value">${test.network}</span>
+            </div>
+            <div class="metadata-item">
+                <span class="metadata-label">Date</span>
+                <span class="metadata-value">${startTime.toLocaleDateString()}</span>
+            </div>
+            <div class="metadata-item">
+                <span class="metadata-label">Time</span>
+                <span class="metadata-value">${startTime.toLocaleTimeString()}</span>
+            </div>
+            <div class="metadata-item">
+                <span class="metadata-label">Duration</span>
+                <span class="metadata-value">${duration}</span>
+            </div>
+            <div class="metadata-item">
+                <span class="metadata-label">Run ID</span>
+                <span class="metadata-value">${test.github?.run_id || 'N/A'}</span>
+            </div>
+        </div>
+        <span class="status-badge ${test.result}">${test.result}</span>
+    `;
+    
+    return card;
+}
+
+// Update trends chart
+function updateTrendsChart() {
+    const ctx = document.getElementById('trendsChart').getContext('2d');
+    
+    // Group results by date
+    const resultsByDate = {};
+    filteredResults.forEach(test => {
+        if (!resultsByDate[test.date]) {
+            resultsByDate[test.date] = { success: 0, failure: 0 };
+        }
+        if (test.result === 'success') {
+            resultsByDate[test.date].success++;
+        } else if (test.result === 'failure') {
+            resultsByDate[test.date].failure++;
+        }
+    });
+    
+    // Sort dates
+    const dates = Object.keys(resultsByDate).sort();
+    
+    // Prepare chart data
+    const chartData = {
+        labels: dates,
+        datasets: [
+            {
+                label: 'Successful Tests',
+                data: dates.map(date => resultsByDate[date].success),
+                backgroundColor: '#28a745',
+                borderColor: '#28a745',
+                borderWidth: 2,
+                tension: 0.1
+            },
+            {
+                label: 'Failed Tests',
+                data: dates.map(date => resultsByDate[date].failure),
+                backgroundColor: '#d73a49',
+                borderColor: '#d73a49',
+                borderWidth: 2,
+                tension: 0.1
+            }
+        ]
+    };
+    
+    // Update or create chart
+    if (trendsChart) {
+        trendsChart.data = chartData;
+        trendsChart.update();
+    } else {
+        trendsChart = new Chart(ctx, {
+            type: 'line',
+            data: chartData,
+            options: {
+                responsive: true,
+                plugins: {
+                    title: {
+                        display: true,
+                        text: 'Test Results Over Time'
+                    },
+                    legend: {
+                        display: true,
+                        position: 'bottom'
+                    }
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            stepSize: 1
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+// Start the app
+document.addEventListener('DOMContentLoaded', init);

--- a/github-pages/index.html
+++ b/github-pages/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kurtosis Sync Test Dashboard</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Kurtosis Sync Test Dashboard</h1>
+            <p>Ethereum Client Synchronization Test Results</p>
+        </header>
+
+        <div class="filters">
+            <div class="filter-group">
+                <label for="dateRange">Date Range:</label>
+                <select id="dateRange">
+                    <option value="3">Last 3 days</option>
+                    <option value="7">Last 7 days</option>
+                    <option value="14">Last 14 days</option>
+                    <option value="30">Last 30 days</option>
+                    <option value="custom">Custom range</option>
+                </select>
+                <div id="customDateRange" style="display: none;">
+                    <input type="date" id="startDate">
+                    <span>to</span>
+                    <input type="date" id="endDate">
+                </div>
+            </div>
+
+            <div class="filter-group">
+                <label for="networkFilter">Network:</label>
+                <select id="networkFilter">
+                    <option value="">All Networks</option>
+                </select>
+            </div>
+
+            <div class="filter-group">
+                <label for="elClientFilter">EL Client:</label>
+                <select id="elClientFilter">
+                    <option value="">All EL Clients</option>
+                    <option value="geth">Geth</option>
+                    <option value="nethermind">Nethermind</option>
+                    <option value="reth">Reth</option>
+                    <option value="besu">Besu</option>
+                    <option value="erigon">Erigon</option>
+                </select>
+            </div>
+
+            <div class="filter-group">
+                <label for="clClientFilter">CL Client:</label>
+                <select id="clClientFilter">
+                    <option value="">All CL Clients</option>
+                    <option value="lighthouse">Lighthouse</option>
+                    <option value="teku">Teku</option>
+                    <option value="prysm">Prysm</option>
+                    <option value="nimbus">Nimbus</option>
+                    <option value="lodestar">Lodestar</option>
+                    <option value="grandine">Grandine</option>
+                </select>
+            </div>
+
+            <div class="filter-group">
+                <label for="statusFilter">Status:</label>
+                <select id="statusFilter">
+                    <option value="">All</option>
+                    <option value="success">Success</option>
+                    <option value="failure">Failure</option>
+                </select>
+            </div>
+
+            <button id="applyFilters">Apply Filters</button>
+        </div>
+
+        <div class="summary-cards">
+            <div class="summary-card">
+                <h3 id="totalTests">0</h3>
+                <p>Total Tests</p>
+            </div>
+            <div class="summary-card success">
+                <h3 id="successfulTests">0</h3>
+                <p>Successful</p>
+            </div>
+            <div class="summary-card failure">
+                <h3 id="failedTests">0</h3>
+                <p>Failed</p>
+            </div>
+            <div class="summary-card">
+                <h3 id="successRate">0%</h3>
+                <p>Success Rate</p>
+            </div>
+        </div>
+
+        <div class="loading" id="loading">Loading test results...</div>
+        <div class="error" id="error" style="display: none;"></div>
+
+        <div class="results-section">
+            <h2>Test Results</h2>
+            <div class="results-grid" id="resultsGrid"></div>
+        </div>
+
+        <div class="charts-section">
+            <h2>Trends</h2>
+            <canvas id="trendsChart"></canvas>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/github-pages/styles.css
+++ b/github-pages/styles.css
@@ -1,0 +1,252 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: #f6f8fa;
+    color: #24292e;
+    line-height: 1.5;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+header {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    padding: 30px;
+    margin-bottom: 20px;
+}
+
+header h1 {
+    color: #24292e;
+    margin-bottom: 5px;
+}
+
+header p {
+    color: #586069;
+}
+
+.filters {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    padding: 20px;
+    margin-bottom: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    align-items: flex-end;
+}
+
+.filter-group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.filter-group label {
+    font-size: 14px;
+    font-weight: 600;
+    color: #586069;
+}
+
+.filter-group select,
+.filter-group input {
+    padding: 8px 12px;
+    border: 1px solid #e1e4e8;
+    border-radius: 6px;
+    font-size: 14px;
+    background: white;
+}
+
+#customDateRange {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-top: 5px;
+}
+
+#applyFilters {
+    padding: 8px 16px;
+    background-color: #0366d6;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+#applyFilters:hover {
+    background-color: #0256c7;
+}
+
+.summary-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 20px;
+    margin-bottom: 30px;
+}
+
+.summary-card {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    padding: 20px;
+    text-align: center;
+}
+
+.summary-card h3 {
+    font-size: 2.5em;
+    color: #24292e;
+    margin-bottom: 5px;
+}
+
+.summary-card p {
+    color: #586069;
+    font-weight: 600;
+}
+
+.summary-card.success h3 {
+    color: #28a745;
+}
+
+.summary-card.failure h3 {
+    color: #d73a49;
+}
+
+.loading {
+    text-align: center;
+    padding: 40px;
+    color: #586069;
+}
+
+.error {
+    background-color: #ffeaea;
+    color: #d73a49;
+    padding: 20px;
+    border-radius: 8px;
+    margin: 20px 0;
+}
+
+.results-section,
+.charts-section {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    padding: 30px;
+    margin-bottom: 20px;
+}
+
+.results-section h2,
+.charts-section h2 {
+    margin-bottom: 20px;
+    color: #24292e;
+}
+
+.results-grid {
+    display: grid;
+    gap: 15px;
+}
+
+.result-card {
+    border: 1px solid #e1e4e8;
+    border-radius: 8px;
+    padding: 20px;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 20px;
+    align-items: center;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.result-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 3px 6px rgba(0,0,0,0.1);
+}
+
+.client-info {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+
+.client-pair {
+    font-weight: 600;
+    color: #24292e;
+}
+
+.test-metadata {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 10px;
+    font-size: 14px;
+    color: #586069;
+}
+
+.metadata-item {
+    display: flex;
+    flex-direction: column;
+}
+
+.metadata-label {
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+    color: #959da5;
+}
+
+.metadata-value {
+    color: #24292e;
+}
+
+.status-badge {
+    padding: 6px 12px;
+    border-radius: 20px;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.status-badge.success {
+    background-color: #d4f4dd;
+    color: #28a745;
+}
+
+.status-badge.failure {
+    background-color: #ffeaea;
+    color: #d73a49;
+}
+
+.status-badge.unknown {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+@media (max-width: 768px) {
+    .filters {
+        flex-direction: column;
+    }
+    
+    .filter-group {
+        width: 100%;
+    }
+    
+    .result-card {
+        grid-template-columns: 1fr;
+        gap: 10px;
+    }
+    
+    .summary-cards {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}


### PR DESCRIPTION
This commit introduces a new `data` branch to store historical test results in JSON format, organized by date and network. It also sets up a GitHub Pages site using a new `github-pages` directory and associated workflows to visualize this data.

Key changes include:
- Added `.github/scripts/save-test-results.sh` to save test metadata to the `data` branch.
- Added `.github/scripts/deploy-to-gh-pages.sh` (deprecated in favor of the new dashboard approach).
- Added `.github/workflows/deploy-github-pages.yml` to deploy the static dashboard files from `github-pages` to the `gh-pages` branch.
- Added `.github/workflows/prune-data-branch.yml` to automatically remove old data from the `data` branch.
- Modified `action.yml` to include an option (`save_to_data_branch`) to trigger the data saving script.
- Modified `comprehensive-sync-test.yml` and `sync-test.yml` workflows to:
  - Use the new `save_to_data_branch` option instead of generating HTML reports directly.
  - Update the job summaries to link to the new GitHub Pages dashboard.
  - Remove the old GitHub Pages deployment steps from the test workflows.
- Added `github-pages/index.html`, `github-pages/styles.css`, and `github-pages/app.js` to create a client-side dashboard that fetches data from the `data` branch.

The primary motivation is to provide a persistent, historical view of test results that is easily accessible via GitHub Pages, without cluttering the main branch or relying on complex server-side rendering. The `data` branch acts as a simple data store, and the GitHub Pages site provides the visualization layer. The pruning workflow ensures the data branch size is managed.