### PR TITLE
docs: Add documentation for --non-blocking-tasks flag

### DIFF
--- a/synctest.sh
+++ b/synctest.sh
@@ -65,6 +65,7 @@ if kurtosis enclave inspect "$enclave" 2> /dev/null 1> /dev/null; then
 else
     echo "start kurtosis enclave '$enclave'..."
 
+    # Run with --non-blocking-tasks to allow parallel task execution for better performance
     kurtosis run github.com/ethpandaops/ethereum-package --enclave "$enclave" --args-file "$config" --image-download always --non-blocking-tasks
 fi
 


### PR DESCRIPTION
## Summary
- Adds clarifying comment to document the purpose of the `--non-blocking-tasks` flag in synctest.sh
- The flag was already present but lacked documentation explaining its purpose
- Improves code readability and maintainability

## Test plan
- [x] Verify comment is properly formatted and clear
- [x] Ensure no functional changes to script behavior
- [x] Script continues to work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)