### PR TITLE
fix: update kurtosis apt source to sdk.kurtosis.com

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -113,7 +113,7 @@ runs:
       shell: bash
       run: |
         echo "Installing Kurtosis CLI..."
-        echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+        echo "deb [trusted=yes] https://sdk.kurtosis.com/kurtosis-cli-release-artifacts/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
         if [ "${{ inputs.kurtosis_version }}" == "latest" ]; then
           sudo apt install kurtosis-cli


### PR DESCRIPTION
The old Gemfury-hosted kurtosis apt repository (apt.fury.io/kurtosis-tech) is no longer supported. This updates the apt source to the new official repository at sdk.kurtosis.com/kurtosis-cli-release-artifacts.